### PR TITLE
Using oauth - suggestions and example implementation (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ There are defined some basic controllers for the Spotify App
 Well, in that case I think you would be interested in two variables:
 * `counsel-spotify-service-name` is the name of the DBUS service counsel-spotify calls to handle the reproduction of a song
 * `counsel-spotify-use-system-bus-p` for some clients that use the system bus instead of the session
+
+---
+plstore and gnupg
+
+I had to put this into ~/.gnupg
+default-cache-ttl 34560000
+max-cache-ttl 34560000
+

--- a/counsel-spotify.el
+++ b/counsel-spotify.el
@@ -5,7 +5,7 @@
 ;; Author: Lautaro García <https://github.com/Lautaro-Garcia>
 ;; URL: https://github.com/Lautaro-Garcia/counsel-spotify
 ;; Package: counsel-spotify
-;; Package-Requires: ((emacs "25.1") (ivy "0.13.0") (oauth2 "0.13"))
+;; Package-Requires: ((emacs "25.1") (ivy "0.13.0") (elisp-oauth-2 "0.0.1") (dash "2.17.0"))
 ;; Version: 0.4.0
 
 ;; This file is not part of GNU Emacs.
@@ -28,12 +28,10 @@
 ;;; Code:
 
 (require 'url)
-(require 'request)
 (require 'dash)
 (require 'json)
 (require 'ivy)
 (require 'dbus)
-(require 'simple-httpd)
 (require 'elisp-oauth-2)
 
 (defgroup  counsel-spotify nil
@@ -429,6 +427,7 @@ With this we can query for APIs that returns user data."
   "Tell Ivy to update the minibuffer candidates with the COMPLETIONS list of playable objects of type TYPE-OF-RESPONSE."
   (ivy-update-candidates (mapcar #'counsel-spotify-get-formatted-object (counsel-spotify-builder type-of-response completions))))
 
+;;;###autoload
 (defun build-authorization-search (prompt search-keyword type)
   ;; note that lexical binding needs to be non-nil
   ;; for this higher order function to work

--- a/counsel-spotify.el
+++ b/counsel-spotify.el
@@ -99,9 +99,9 @@ Some clients, such as mopidy, can run as system services."
   "Return the Basic auth string that should be sent to ask for an auth token."
   (concat "Basic " (base64-encode-string (concat counsel-spotify-client-id ":" counsel-spotify-client-secret) t)))
 
-;; integrate elisp oauth2 wip
-(defun init-oauth2 ()
-  (elisp-oauth2-init
+;; integrate elisp oauth-2 wip
+(defun init-oauth-2 ()
+  (elisp-oauth-2-init
    counsel-spotify-spotify-api-token-url
    counsel-spotify-spotify-api-auth-url
    counsel-spotify-client-id
@@ -112,19 +112,19 @@ Some clients, such as mopidy, can run as system services."
 (defun counsel-spotify-build-result (type &rest data &allow-other-keys)
   (counsel-spotify-update-ivy-candidates type (plist-get data :data)))
 
-(cl-defun elisp-oauth2-search (&rest rest)
+(cl-defun elisp-oauth-2-search (&rest rest)
   (let ((type (or (plist-get rest :type) 'track))
         (query-url (apply #'counsel-spotify-make-query rest)))
     (elisp-oauth-2-request
      query-url
      (-partial 'counsel-spotify-build-result type))))
 
-(defmacro counsel-spotify-search-integrate-elisp-oauth2 (search-keyword &rest search-args)
-  "Proof of concept for integrating elisp-oauth2.
+(defmacro counsel-spotify-search-integrate-elisp-oauth-2 (search-keyword &rest search-args)
+  "Proof of concept for integrating elisp-oauth-2.
    Only one type of Spotify API call can be called for this.
    The plan is to make it similar to the existing spotify search to make it multimethod-esque."
   `(lambda (search-term)
-     (elisp-oauth2-search ,search-keyword search-term ,@search-args)
+     (elisp-oauth-2-search ,search-keyword search-term ,@search-args)
      0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -189,7 +189,7 @@ Some clients, such as mopidy, can run as system services."
   "Search something in Spotify, based on the query described in REST."
   (let ((type (or (plist-get rest :type) 'track))
         (query-url (apply #'counsel-spotify-make-query rest)))
-    (counsel-spotify-with-oauth2-query-results
+    (counsel-spotify-with-oauth-2-query-results
      query-url
      results ;; results variable to use in the the callback macro
      (counsel-spotify-update-ivy-candidates type results))))
@@ -531,7 +531,7 @@ Current user is the user that you used to log in to spotify api console to get t
 ;; oauth elisp integration proof of concept ;;
 
 ;; provided correct and sufficient variables, this runs only once per session
-(init-oauth2)
+(init-oauth-2)
 
 (defun counsel-spotify-search-user-playlist-2 ()
   "Bring Ivy frontend to choose and play a playlist for the current user.
@@ -539,7 +539,7 @@ Current user is the user that you used to log in to spotify api console to get t
   (interactive)
   (counsel-spotify-verify-credentials)
   (ivy-read "Seach user playlist: "
-            (counsel-spotify-search-integrate-elisp-oauth2 :user-playlist :type 'user-playlist)
+            (counsel-spotify-search-integrate-elisp-oauth-2 :user-playlist :type 'user-playlist)
             :dynamic-collection t
             :action #'counsel-spotify-play-property))
 
@@ -548,10 +548,9 @@ Current user is the user that you used to log in to spotify api console to get t
   (interactive)
   (counsel-spotify-verify-credentials)
   (ivy-read "Search show: "
-            (counsel-spotify-search-integrate-elisp-oauth2 :show :type 'show)
+            (counsel-spotify-search-integrate-elisp-oauth-2 :show :type 'show)
             :dynamic-collection t
             :action #'counsel-spotify-play-property))
-
 
 (provide 'counsel-spotify)
 ;;; counsel-spotify.el ends here

--- a/counsel-spotify.el
+++ b/counsel-spotify.el
@@ -116,7 +116,7 @@ Some clients, such as mopidy, can run as system services."
   (let ((type (or (plist-get rest :type) 'track))
         (query-url (apply #'counsel-spotify-make-query rest)))
     (elisp-oauth-2-request
-     query-url
+     (url-encode-url query-url)
      (-partial 'counsel-spotify-build-result type))))
 
 (defmacro counsel-spotify-search-integrate-elisp-oauth-2 (search-keyword &rest search-args)
@@ -175,11 +175,11 @@ Some clients, such as mopidy, can run as system services."
         track) (concat counsel-spotify-spotify-api-url
                        "/search?q="
                        (when artist (format "artist:%s" artist))
-                       (when album ((format "" ) " album:%s" album))
+                       (when album (format "album:%s" album))
                        (when track (format "track:%s" track))
                        (when episode (format "name:%s" episode))
                        (when playlist (format "%s" playlist))
-                       (when show (format "name:%s" show))
+                       (when show (format "%s" show))
                        (when type (format "&type=%s" (symbol-name type)))))
    (user-playlist (concat counsel-spotify-spotify-api-url "/me/playlists"))
    (new-releases (concat counsel-spotify-spotify-api-url "/browse/new-releases"))

--- a/elisp-oauth-2.el
+++ b/elisp-oauth-2.el
@@ -1,14 +1,14 @@
 ;;; elisp-oauth-2.el --- description -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2020 John Doe
+;; Copyright (C) 2020 Ryuei Sasaki
 ;;
-;; Author: John Doe <http://github/george>
-;; Maintainer: John Doe <john@doe.com>
+;; Author: Ryuei Sasaki <https://github.com/louixs> <https://github.com/ryueisasaki>
+;; Maintainer: Ryuei Sasaki
 ;; Created: May 17, 2020
 ;; Modified: May 17, 2020
 ;; Version: 0.0.1
 ;; Keywords:
-;; Homepage: https://github.com/george/elisp-oauth-2
+;; Homepage: https://github.com/louixs/elisp-oauth-2
 ;; Package-Requires: ((emacs 26.3) (cl-lib "0.5"))
 ;;
 ;; This file is not part of GNU Emacs.
@@ -188,7 +188,7 @@ Access token gets refreshed if necessary."
           (progn (setq ran? t)
                  (apply fn args))))))
 
-(defun elisp-oauth2-set-vars (token-url oauth-url client-id client-secret scopes refresh-token)
+(defun elisp-oauth-2-set-vars (token-url oauth-url client-id client-secret scopes refresh-token)
   ""
   (setq elisp-oauth-2-api-token-url token-url
         elisp-oauth-2-api-auth-url oauth-url
@@ -198,12 +198,12 @@ Access token gets refreshed if necessary."
         elisp-oauth-2-oauth-refresh-token refresh-token)
   (message "set vars finished"))
 
-(setq _elisp-oauth2-set-vars (once 'elisp-oauth2-set-vars))
+(setq _elisp-oauth-2-set-vars (once 'elisp-oauth-2-set-vars))
 
 ;;;###autoload
-(defun elisp-oauth2-init (token-url oauth-url client-id client-secret scopes refresh-token)
+(defun elisp-oauth-2-init (token-url oauth-url client-id client-secret scopes refresh-token)
   "TODO: add doc"
-  (funcall _elisp-oauth2-set-vars token-url oauth-url client-id client-secret scopes refresh-token))
+  (funcall _elisp-oauth-2-set-vars token-url oauth-url client-id client-secret scopes refresh-token))
 
 ;;;###autoload
 (defun elisp-oauth-2-request (url callback)

--- a/elisp-oauth-2.el
+++ b/elisp-oauth-2.el
@@ -1,0 +1,222 @@
+;;; elisp-oauth-2.el --- description -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2020 John Doe
+;;
+;; Author: John Doe <http://github/george>
+;; Maintainer: John Doe <john@doe.com>
+;; Created: May 17, 2020
+;; Modified: May 17, 2020
+;; Version: 0.0.1
+;; Keywords:
+;; Homepage: https://github.com/george/elisp-oauth-2
+;; Package-Requires: ((emacs 26.3) (cl-lib "0.5"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  description
+;;
+;;; Code:
+(require 'request)
+(require 'simple-httpd)
+
+(defvar elisp-oauth-2-api-token-url ""
+  "Variable to define spotify API url for getting the access token.")
+
+(defvar elisp-oauth-2-api-auth-url ""
+  "Variable to define spotify API url for authorization.")
+
+(defvar elisp-oauth-2-redirect-uri-port "8080"
+  "Variable to define spotify API url for authorization.")
+
+(defvar elisp-oauth-2-redirect-uri (concat "http://localhost:"
+                                           elisp-oauth-2-redirect-uri-port)
+  "Variable to define spotify API url for authorization.")
+
+(defvar elisp-oauth-2-client-id ""
+  "Spotify application client ID.")
+
+(defvar elisp-oauth-2-client-secret ""
+  "Spotify application client secret.")
+
+(defvar elisp-oauth-2-oauth-refresh-token nil
+  "")
+
+(defvar elisp-oauth-2-oauth-access-token nil
+  "")
+
+(defvar elisp-oauth-2-oauth-code nil
+  "")
+
+(defvar elisp-oauth-2-scopes ""
+  "Spotify application oauth scope.")
+
+(defvar elisp-oauth-2-oauth-access-token-expires-at 0
+  "The time that the current oauth access token will expire in unix timestamp.")
+
+;; http server
+(defun start-redirect-server ()
+  (setq httpd-root "www/"
+        httpd-port "8080")
+  (httpd-start))
+
+(defun stop-redirect-server ()
+  (print "Stopping web server...")
+  (httpd-stop)
+  (kill-buffer "*httpd*"))
+
+(defun elisp-oauth-2-set-auth-code ()
+  "TODO: add doc."
+  (setq elisp-oauth-2-oauth-code (read-string "Enter the code your browser displayed: ")))
+
+(defvar elisp-oauth-2-oauth-url
+  (concat "%s"
+          "?client_id=%s"
+          "&response_type=code"
+          "&redirect_uri=%s"
+          "&scope=%s")
+  "The OAuth URL/endpoint.")
+
+(defun elisp-oauth-2-build-oauth-url ()
+  "TODO: add doc."
+  (format elisp-oauth-2-oauth-url
+          elisp-oauth-2-api-auth-url
+          elisp-oauth-2-client-id
+          elisp-oauth-2-redirect-uri
+          elisp-oauth-2-scopes))
+
+(defun elisp-oauth-2-fetch-oauth-token ()
+  "TODO: add doc."
+  (start-redirect-server)
+  ;; endpoint /authorize
+  ;; query params
+  ;; client_id, resonse_type, redirect_uri, scope
+  (browse-url (elisp-oauth-2-build-oauth-url))
+  (elisp-oauth-2-set-auth-code)
+  (stop-redirect-server))
+
+;; refresh token
+(defun elisp-oauth-2-get-current-time ()
+  (string-to-number (shell-command-to-string "date +%s")))
+
+(defun elisp-oauth-2-oauth-set-access-token-expires-at (expires-in)
+  (let ((expires-at (+ (elisp-oauth-2-get-current-time) expires-in)))
+    (setq elisp-oauth-2-oauth-access-token-expires-at expires-at)))
+
+(defun elisp-oauth-2-refresh-oauth-token? ()
+  "Return non-nil if oauth access token needs to be refreshed."
+  (< elisp-oauth-2-oauth-access-token-expires-at
+     (elisp-oauth-2-get-current-time)))
+
+(cl-defun elisp-oauth-2-oauth-fetch-callback (&rest data &allow-other-keys)
+  "Callback to run when the oauth code fetch is complete."
+  (let-alist (plist-get data :data)
+    (unless (and .access_token .refresh_token .expires_in)
+      (message "elisp-oauth-2: Failed to fetch OAuth access_token and refresh_token values!")
+      (error "elisp-oauth-2: Failed to fetch OAuth access_token and refresh_token values!"))
+    (setq elisp-oauth-2-oauth-access-token .access_token)
+    (setq elisp-oauth-2-oauth-refresh-token .refresh_token)
+    (elisp-oauth-2-oauth-set-access-token-expires-at .expires_in)
+    ;; @todo Handle expires_in value (should be ~1 hour, so refresh before then)
+    (message
+     "Tokens set - consider adding elisp-oauth-2-oauth-refresh-token values to your init file to avoid signing in again in the future sessions.")))
+
+(defun elisp-oauth-2-oauth-fetch-authorization-token ()
+  "Make the initial code request for OAuth."
+  (request elisp-oauth-2-api-token-url
+    :complete #'elisp-oauth-2-oauth-fetch-callback
+    :sync t
+    :data (concat "client_id=" elisp-oauth-2-client-id
+                  "&client_secret=" elisp-oauth-2-client-secret
+                  "&code=" elisp-oauth-2-oauth-code
+                  "&redirect_uri=" elisp-oauth-2-redirect-uri
+                  "&grant_type=authorization_code")
+    :type "POST"
+    :parser 'json-read
+    :headers '(("Content-Type" . "application/x-www-form-urlencoded"))))
+
+;; TODO: refactor
+(cl-defun elisp-oauth-2-oauth-refresh-callback (&rest data &allow-other-keys)
+  "Callback to run when the oauth code fetch is complete."
+  (let-alist (plist-get data :data)
+    (unless (and .access_token .expires_in)
+      (message "counsel-spotify: Failed to fetch OAuth access_token values!")
+      (error "counsel-spotify: Failed to fetch OAuth access_token values!"))
+    (setq elisp-oauth-2-oauth-access-token .access_token)
+    (elisp-oauth-2-oauth-set-access-token-expires-at .expires_in)
+    (message
+     "Refresh token successful!")))
+
+(defun elisp-oauth-2-oauth-refresh-authorization-token ()
+  "Get new oauth access and refresh token using refresh token."
+  (request elisp-oauth-2-api-token-url
+    :complete #'elisp-oauth-2-oauth-refresh-callback
+    :sync t
+    :data (concat "client_id=" elisp-oauth-2-client-id
+                  "&client_secret=" elisp-oauth-2-client-secret
+                  "&refresh_token=" elisp-oauth-2-oauth-refresh-token
+                  "&grant_type=refresh_token")
+    :type "POST"
+    :parser 'json-read
+    :headers '(("Content-Type" . "application/x-www-form-urlencoded"))))
+
+(defun elisp-oauth-2-fetch-and-set-tokens ()
+  ""
+  (elisp-oauth-2-fetch-oauth-token)
+  (elisp-oauth-2-oauth-fetch-authorization-token))
+
+;;;###autoload
+(defun elisp-oauth-2-handle-oauth ()
+  "Retrieve oauth access token and refresh token if they are nil.
+Access token gets refreshed if necessary."
+  (cond ((and elisp-oauth-2-oauth-refresh-token
+              (elisp-oauth-2-refresh-oauth-token?))
+         (elisp-oauth-2-oauth-refresh-authorization-token))
+        ((or (not elisp-oauth-2-oauth-refresh-token)
+             (not elisp-oauth-2-oauth-access-token))
+         (elisp-oauth-2-fetch-and-set-tokens))
+        (t nil)))
+
+;; once implementation
+;;(setq lexical-binding t)
+
+(defun once (fn)
+  (let ((ran? nil))
+    (lambda (&rest args)
+      (when (not ran?)
+          (progn (setq ran? t)
+                 (apply fn args))))))
+
+(defun elisp-oauth2-set-vars (token-url oauth-url client-id client-secret scopes refresh-token)
+  ""
+  (setq elisp-oauth-2-api-token-url token-url
+        elisp-oauth-2-api-auth-url oauth-url
+        elisp-oauth-2-client-id client-id
+        elisp-oauth-2-client-secret client-secret
+        elisp-oauth-2-scopes scopes
+        elisp-oauth-2-oauth-refresh-token refresh-token)
+  (message "set vars finished"))
+
+(setq _elisp-oauth2-set-vars (once 'elisp-oauth2-set-vars))
+
+;;;###autoload
+(defun elisp-oauth2-init (token-url oauth-url client-id client-secret scopes refresh-token)
+  "TODO: add doc"
+  (funcall _elisp-oauth2-set-vars token-url oauth-url client-id client-secret scopes refresh-token))
+
+;;;###autoload
+(defun elisp-oauth-2-request (url callback)
+  "Wrapper for request to do http calls.
+URL - api endpoint
+CALLBACK - callback function
+TODO: make request type configurable."
+  (elisp-oauth-2-handle-oauth)
+  (request url
+    :complete callback
+    :type "GET"
+    :parser 'json-read
+    :headers `(("Authorization" . ,(format  "Bearer %s" elisp-oauth-2-oauth-access-token)))))
+
+(provide 'elisp-oauth-2)
+;;; elisp-oauth-2.el ends here

--- a/www/index.htm
+++ b/www/index.htm
@@ -1,0 +1,24 @@
+<!doctype html>
+
+<html>
+  <head>
+    <title>Oauth</title>
+  </head>
+
+  <body style="width: 70vw;">
+    <div style="margin-bottom: .5em;">
+      Copy the access token below and paste it in the Emacs prompt:
+    </div>
+    <div style="overflow-wrap: anywhere;">
+      <textarea style="height: 5em;
+                       width: 80%;"
+                id="token">
+      </textarea>
+      <div style="margin-top: .5em;">
+        <button id="copy">Copy</button>
+      </div>
+      <div id="result"></div>
+    </div>
+    <script type="application/javascript" src="scripts.js"></script>
+  </body>
+</html>

--- a/www/scripts.js
+++ b/www/scripts.js
@@ -1,0 +1,32 @@
+function getElem(selector) {
+    return document.querySelector(selector);
+}
+
+function getToken() {
+    const urlSearch = window.location.search;
+    const token = urlSearch.split("?code=")[1];
+    if (typeof token == "undefined") {
+        return "Token was not found. Please try again. If it's still not working please report the error.";
+    }
+    return token;
+}
+
+function copy() {
+    let text = document.querySelector("#token");
+    let resultElem = getElem("#result");
+    text.select();
+    try {
+        document.execCommand("copy");
+        resultElem.innerText = "Copied!";
+    }
+    catch(error) {
+        console.error(error);
+        resultElem.innerText = "Text was not copied. Please try again or report the error.";
+    }
+}
+
+// Obtain token from url hash and display
+getElem("#token").innerText = getToken();
+
+// add event listener for the copy button
+getElem("#copy").addEventListener("click", copy);


### PR DESCRIPTION
Hi @Lautaro-Garcia!

It's me again.

I've been thinking about extending this package to use oauth so we can choose from wider selection of Spotify API. For example, I found out that shows and episodes search wasn't possible with access token. Another example would be to have access to user playlists rather than the generic search across all Spotify playlists (i.e. my earlier commit I sent for pull request).
I've included all my example above in this preliminary work.

This is still not ready yet but I wanted to see what you think of the idea of using oauth.

There are also a few caveats if we completely switch from access token to oauth.
Oauth2 package which I'm using here doesn't seem to handle token refresh well. So we may have to implement refresh logic ourselves. Oauth2 package stores tokens using plstore package which caused some issues on my machine when setting up gpg. Basically this can cause annoyances among the users who are happy with what this package already provides with access token. So one thought that occurred to me is to keep the usage of access token until user wants to use APIs that require Oauth tokens.

I hope you are staying safe in this difficult time. And it would be great to have some of your thoughts on this! (Just to make sure this is still work in progress)

Many thanks!